### PR TITLE
Convert gitlab-source-group/deploy_file_shared to GitHub Actions

### DIFF
--- a/.github/workflows/deploy_file_shared.yml
+++ b/.github/workflows/deploy_file_shared.yml
@@ -1,0 +1,19 @@
+name: gitlab-source-group/deploy_file_shared
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Deploying.."


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/gitlab-source-group/deploy_file_shared) :tada: